### PR TITLE
NEW Allow files to have a .tmpl extension which is stripped

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: php
+
+php:
+  - 7.1
+  - 7.2
+  - nightly
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: nightly
+
+before_script:
+  - composer validate
+  - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
+
+script:
+  - vendor/bin/phpunit tests/

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,11 @@
             "SilverStripe\\RecipePlugin\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "SilverStripe\\Test\\RecipePlugin\\": "src/"
+        }
+    },
     "extra": {
         "class": "SilverStripe\\RecipePlugin\\RecipePlugin",
         "branch-alias": {
@@ -24,6 +29,7 @@
         "composer-plugin-api": "^1.1"
     },
     "require-dev": {
+        "phpunit/phpunit": "^7",
         "composer/composer": "^1.2"
     },
     "minimum-stability": "dev"

--- a/src/RecipeInstaller.php
+++ b/src/RecipeInstaller.php
@@ -44,6 +44,10 @@ class RecipeInstaller extends LibraryInstaller {
         $any = false;
         foreach($fileIterator as $path => $info) {
             $destination = $destinationRoot . substr($path, strlen($sourceRoot));
+            $extension = pathinfo($destination, PATHINFO_EXTENSION);
+            if ($extension === 'tmpl') {
+                $destination = substr($destination, -5);
+            }
             $relativePath = substr($path, strlen($sourceRoot) + 1); // Name path without leading '/'
 
             // Write header

--- a/src/RecipeInstaller.php
+++ b/src/RecipeInstaller.php
@@ -97,11 +97,13 @@ class RecipeInstaller extends LibraryInstaller {
         // If any files are written, modify composer.json with newly installed files
         if ($installedFiles) {
             sort($installedFiles);
+            $composerFile = $this->getComposerFile();
+            $composerData = $composerFile->read();
             if (!isset($composerData['extra'])) {
                 $composerData['extra'] = [];
             }
             $composerData['extra'][$registrationKey] = $installedFiles;
-            $this->getComposerFile()->write($composerData);
+            $composerFile->write($composerData);
         }
     }
 

--- a/tests/RecipeInstallerTest.php
+++ b/tests/RecipeInstallerTest.php
@@ -1,0 +1,412 @@
+<?php
+
+namespace SilverStripe\Test\RecipePlugin;
+
+use Composer\Composer;
+use Composer\Config;
+use Composer\IO\IOInterface;
+use Composer\Json\JsonFile;
+use Composer\Util\Filesystem;
+use PHPUnit\Framework\TestCase;
+use SilverStripe\RecipePlugin\RecipeInstaller;
+
+class RecipeInstallerTest extends TestCase
+{
+
+    public function testInstallProjectFilesFresh()
+    {
+        $recipeName = 'test';
+        $sourceRoot = '/source';
+        $destinationRoot = '/destination';
+        $registrationKey = 'key';
+        $projectName = 'test project';
+
+        $messages = [];
+        $io = $this->getMockBuilder(IOInterface::class)
+            ->setMethods([])
+            ->getMock();
+        $io->expects($this->exactly(2))->method('write')->willReturnCallback(function ($message) use (&$messages) {
+            $messages[] = $message;
+        });
+        $composer = $this->getMockBuilder(Composer::class)
+            ->setMethods([
+                'getConfig',
+            ])->getMock();
+        $composer->method('getConfig')->willReturn(new Config());
+
+        $filesystem = $this->getMockBuilder(Filesystem::class)->setMethods([])->getMock();
+        $filesystem->expects($this->once())->method('ensureDirectoryExists')->with(
+            $destinationRoot
+        );
+        $filesystem->expects($this->once())->method('copy')->with(
+            $sourceRoot . '/file.php.tmpl',
+            $destinationRoot . '/file.php'
+        );
+
+        $mockInstaller = $this->getMockBuilder(RecipeInstaller::class)
+            ->setConstructorArgs([
+                $io,
+                $composer,
+                null,
+                $filesystem,
+            ])
+            ->setMethods([
+                'getFileIterator',
+                'getInstalledFiles',
+                'fileExists',
+                'getComposerFile',
+            ])
+            ->getMock();
+        $mockInstaller->method('getFileIterator')->willReturn([
+            $sourceRoot . '/file.php.tmpl' => [],
+        ]);
+        $mockInstaller->method('fileExists')->willReturn(false);
+        $mockInstaller->method('getInstalledFiles')->willReturn([]);
+        $mockInstaller->method('getComposerFile')->willReturn(
+            $jsonFile = $this->getMockBuilder(JsonFile::class)
+                ->disableOriginalConstructor()
+                ->setMethods([])
+                ->getMock()
+        );
+
+        $jsonFile->expects($this->once())->method('write')->willReturnCallback(function ($data) use ($registrationKey) {
+            $this->assertArrayHasKey('extra', $data);
+            $this->assertArrayHasKey($registrationKey, $data['extra']);
+            $this->assertCount(1, $data['extra'][$registrationKey]);
+            $this->assertContains('file.php', $data['extra'][$registrationKey]);
+        });
+
+        $reflectionClass = new \ReflectionClass($mockInstaller);
+        $reflectionMethod = $reflectionClass->getMethod('installProjectFiles');
+        $reflectionMethod->setAccessible(true);
+        $reflectionMethod->invokeArgs($mockInstaller, [
+            $recipeName,
+            $sourceRoot,
+            $destinationRoot,
+            '*.php',
+            $registrationKey,
+            $projectName,
+        ]);
+
+        // perhaps theses tests are needlessly tightly coupled to the output
+        $this->assertCount(2, $messages);
+        $this->assertContains(sprintf('Installing %s files for recipe <info>%s</info>', $projectName, $recipeName), $messages[0]);
+        $this->assertContains('Copying <info>file.php</info>', $messages[1]);
+    }
+
+    public function testInstallProjectFilesExistsSame()
+    {
+        $recipeName = 'test';
+        $sourceRoot = '/source';
+        $destinationRoot = '/destination';
+        $registrationKey = 'key';
+        $projectName = 'test project';
+
+        $messages = [];
+        $io = $this->getMockBuilder(IOInterface::class)
+            ->setMethods([])
+            ->getMock();
+        $io->expects($this->exactly(2))->method('write')->willReturnCallback(function ($message) use (&$messages) {
+            $messages[] = $message;
+        });
+        $composer = $this->getMockBuilder(Composer::class)
+            ->setMethods([
+                'getConfig',
+            ])->getMock();
+        $composer->method('getConfig')->willReturn(new Config());
+
+        $filesystem = $this->getMockBuilder(Filesystem::class)->setMethods([])->getMock();
+        $filesystem->expects($this->never())->method('copy');
+
+        $mockInstaller = $this->getMockBuilder(RecipeInstaller::class)
+            ->setConstructorArgs([
+                $io,
+                $composer,
+                null,
+                $filesystem,
+            ])
+            ->setMethods([
+                'getFileIterator',
+                'getInstalledFiles',
+                'fileExists',
+                'fileGetContents',
+                'getComposerFile',
+            ])
+            ->getMock();
+        $mockInstaller->method('getFileIterator')->willReturn([
+            $sourceRoot . '/file.php.tmpl' => [],
+        ]);
+        $mockInstaller->method('fileExists')->willReturn(true);
+        $mockInstaller->expects($this->exactly(2))->method('fileGetContents')->willReturn('contents');
+        $mockInstaller->method('getInstalledFiles')->willReturn([]);
+        $mockInstaller->method('getComposerFile')->willReturn(
+            $jsonFile = $this->getMockBuilder(JsonFile::class)
+                ->disableOriginalConstructor()
+                ->setMethods([])
+                ->getMock()
+        );
+
+        $jsonFile->expects($this->once())->method('write')->willReturnCallback(function ($data) use ($registrationKey) {
+            $this->assertArrayHasKey('extra', $data);
+            $this->assertArrayHasKey($registrationKey, $data['extra']);
+            $this->assertCount(1, $data['extra'][$registrationKey]);
+            $this->assertContains('file.php', $data['extra'][$registrationKey]);
+        });
+
+        $reflectionClass = new \ReflectionClass($mockInstaller);
+        $reflectionMethod = $reflectionClass->getMethod('installProjectFiles');
+        $reflectionMethod->setAccessible(true);
+        $reflectionMethod->invokeArgs($mockInstaller, [
+            $recipeName,
+            $sourceRoot,
+            $destinationRoot,
+            '*.php',
+            $registrationKey,
+            $projectName,
+        ]);
+
+        // perhaps theses tests are needlessly tightly coupled to the output
+        $this->assertCount(2, $messages);
+        $this->assertContains(sprintf('Installing %s files for recipe <info>%s</info>', $projectName, $recipeName), $messages[0]);
+        $this->assertContains('Skipping <info>file.php</info> (<comment>existing, but unchanged</comment>)', $messages[1]);
+    }
+
+    public function testInstallProjectFilesExistsDifferent()
+    {
+        $recipeName = 'test';
+        $sourceRoot = '/source';
+        $destinationRoot = '/destination';
+        $registrationKey = 'key';
+        $projectName = 'test project';
+
+        $messages = [];
+        $io = $this->getMockBuilder(IOInterface::class)
+            ->setMethods([])
+            ->getMock();
+        $io->expects($this->exactly(2))->method('write')->willReturnCallback(function ($message) use (&$messages) {
+            $messages[] = $message;
+        });
+        $composer = $this->getMockBuilder(Composer::class)
+            ->setMethods([
+                'getConfig',
+            ])->getMock();
+        $composer->method('getConfig')->willReturn(new Config());
+
+        $filesystem = $this->getMockBuilder(Filesystem::class)->setMethods([])->getMock();
+        $filesystem->expects($this->never())->method('copy');
+
+        $mockInstaller = $this->getMockBuilder(RecipeInstaller::class)
+            ->setConstructorArgs([
+                $io,
+                $composer,
+                null,
+                $filesystem,
+            ])
+            ->setMethods([
+                'getFileIterator',
+                'getInstalledFiles',
+                'fileExists',
+                'fileGetContents',
+                'getComposerFile',
+            ])
+            ->getMock();
+        $mockInstaller->method('getFileIterator')->willReturn([
+            $sourceRoot . '/file.php.tmpl' => [],
+        ]);
+        $mockInstaller->method('fileExists')->willReturn(true);
+        $mockInstaller->expects($this->exactly(2))->method('fileGetContents')->willReturnOnConsecutiveCalls(
+            'contents', 'different contents'
+        );
+        $mockInstaller->method('getInstalledFiles')->willReturn([]);
+        $mockInstaller->method('getComposerFile')->willReturn(
+            $jsonFile = $this->getMockBuilder(JsonFile::class)
+                ->disableOriginalConstructor()
+                ->setMethods([])
+                ->getMock()
+        );
+
+        $jsonFile->expects($this->once())->method('write')->willReturnCallback(function ($data) use ($registrationKey) {
+            $this->assertArrayHasKey('extra', $data);
+            $this->assertArrayHasKey($registrationKey, $data['extra']);
+            $this->assertCount(1, $data['extra'][$registrationKey]);
+            $this->assertContains('file.php', $data['extra'][$registrationKey]);
+        });
+
+        $reflectionClass = new \ReflectionClass($mockInstaller);
+        $reflectionMethod = $reflectionClass->getMethod('installProjectFiles');
+        $reflectionMethod->setAccessible(true);
+        $reflectionMethod->invokeArgs($mockInstaller, [
+            $recipeName,
+            $sourceRoot,
+            $destinationRoot,
+            '*.php',
+            $registrationKey,
+            $projectName,
+        ]);
+
+        // perhaps theses tests are needlessly tightly coupled to the output
+        $this->assertCount(2, $messages);
+        $this->assertContains(sprintf('Installing %s files for recipe <info>%s</info>', $projectName, $recipeName), $messages[0]);
+        $this->assertContains('Skipping <info>file.php</info> (<comment>existing and modified in project</comment>)', $messages[1]);
+    }
+
+    public function testInstallProjectFilesRemoved()
+    {
+        $recipeName = 'test';
+        $sourceRoot = '/source';
+        $destinationRoot = '/destination';
+        $registrationKey = 'key';
+        $projectName = 'test project';
+
+        $messages = [];
+        $io = $this->getMockBuilder(IOInterface::class)
+            ->setMethods([])
+            ->getMock();
+        $io->expects($this->exactly(2))->method('write')->willReturnCallback(function ($message) use (&$messages) {
+            $messages[] = $message;
+        });
+        $composer = $this->getMockBuilder(Composer::class)
+            ->setMethods([
+                'getConfig',
+            ])->getMock();
+        $composer->method('getConfig')->willReturn(new Config());
+
+        $filesystem = $this->getMockBuilder(Filesystem::class)->setMethods([])->getMock();
+        $filesystem->expects($this->never())->method('copy');
+
+        $mockInstaller = $this->getMockBuilder(RecipeInstaller::class)
+            ->setConstructorArgs([
+                $io,
+                $composer,
+                null,
+                $filesystem,
+            ])
+            ->setMethods([
+                'getFileIterator',
+                'getInstalledFiles',
+                'fileExists',
+                'fileGetContents',
+                'getComposerFile',
+            ])
+            ->getMock();
+        $mockInstaller->method('getFileIterator')->willReturn([
+            $sourceRoot . '/file.php.tmpl' => [],
+        ]);
+        $mockInstaller->method('fileExists')->willReturn(false);
+        $mockInstaller->expects($this->never())->method('fileGetContents');
+        $mockInstaller->method('getInstalledFiles')->willReturn([
+            'file.php',
+        ]);
+        $mockInstaller->method('getComposerFile')->willReturn(
+            $jsonFile = $this->getMockBuilder(JsonFile::class)
+                ->disableOriginalConstructor()
+                ->setMethods([])
+                ->getMock()
+        );
+
+        $jsonFile->expects($this->once())->method('write')->willReturnCallback(function ($data) use ($registrationKey) {
+            $this->assertArrayHasKey('extra', $data);
+            $this->assertArrayHasKey($registrationKey, $data['extra']);
+            $this->assertCount(1, $data['extra'][$registrationKey]);
+            $this->assertContains('file.php', $data['extra'][$registrationKey]);
+        });
+
+        $reflectionClass = new \ReflectionClass($mockInstaller);
+        $reflectionMethod = $reflectionClass->getMethod('installProjectFiles');
+        $reflectionMethod->setAccessible(true);
+        $reflectionMethod->invokeArgs($mockInstaller, [
+            $recipeName,
+            $sourceRoot,
+            $destinationRoot,
+            '*.php',
+            $registrationKey,
+            $projectName,
+        ]);
+
+        // perhaps theses tests are needlessly tightly coupled to the output
+        $this->assertCount(2, $messages);
+        $this->assertContains(sprintf('Installing %s files for recipe <info>%s</info>', $projectName, $recipeName), $messages[0]);
+        $this->assertContains('Skipping <info>file.php</info> (<comment>previously installed</comment>)', $messages[1]);
+    }
+
+    public function testInstallProjectFilesWithoutTmplExtension()
+    {
+        $recipeName = 'test';
+        $sourceRoot = '/source';
+        $destinationRoot = '/destination';
+        $registrationKey = 'key';
+        $projectName = 'test project';
+
+        $messages = [];
+        $io = $this->getMockBuilder(IOInterface::class)
+            ->setMethods([])
+            ->getMock();
+        $io->expects($this->exactly(2))->method('write')->willReturnCallback(function ($message) use (&$messages) {
+            $messages[] = $message;
+        });
+        $composer = $this->getMockBuilder(Composer::class)
+            ->setMethods([
+                'getConfig',
+            ])->getMock();
+        $composer->method('getConfig')->willReturn(new Config());
+
+        $filesystem = $this->getMockBuilder(Filesystem::class)->setMethods([])->getMock();
+        $filesystem->expects($this->once())->method('ensureDirectoryExists')->with(
+            $destinationRoot
+        );
+        $filesystem->expects($this->once())->method('copy')->with(
+            $sourceRoot . '/file.php',
+            $destinationRoot . '/file.php'
+        );
+
+        $mockInstaller = $this->getMockBuilder(RecipeInstaller::class)
+            ->setConstructorArgs([
+                $io,
+                $composer,
+                null,
+                $filesystem,
+            ])
+            ->setMethods([
+                'getFileIterator',
+                'getInstalledFiles',
+                'fileExists',
+                'getComposerFile',
+            ])
+            ->getMock();
+        $mockInstaller->method('getFileIterator')->willReturn([
+            $sourceRoot . '/file.php' => [],
+        ]);
+        $mockInstaller->method('fileExists')->willReturn(false);
+        $mockInstaller->method('getInstalledFiles')->willReturn([]);
+        $mockInstaller->method('getComposerFile')->willReturn(
+            $jsonFile = $this->getMockBuilder(JsonFile::class)
+                ->disableOriginalConstructor()
+                ->setMethods([])
+                ->getMock()
+        );
+
+        $jsonFile->expects($this->once())->method('write')->willReturnCallback(function ($data) use ($registrationKey) {
+            $this->assertArrayHasKey('extra', $data);
+            $this->assertArrayHasKey($registrationKey, $data['extra']);
+            $this->assertCount(1, $data['extra'][$registrationKey]);
+            $this->assertContains('file.php', $data['extra'][$registrationKey]);
+        });
+
+        $reflectionClass = new \ReflectionClass($mockInstaller);
+        $reflectionMethod = $reflectionClass->getMethod('installProjectFiles');
+        $reflectionMethod->setAccessible(true);
+        $reflectionMethod->invokeArgs($mockInstaller, [
+            $recipeName,
+            $sourceRoot,
+            $destinationRoot,
+            '*.php',
+            $registrationKey,
+            $projectName,
+        ]);
+
+        // perhaps theses tests are needlessly tightly coupled to the output
+        $this->assertCount(2, $messages);
+        $this->assertContains(sprintf('Installing %s files for recipe <info>%s</info>', $projectName, $recipeName), $messages[0]);
+        $this->assertContains('Copying <info>file.php</info>', $messages[1]);
+    }
+}


### PR DESCRIPTION
Allows a fix for https://github.com/silverstripe/recipe-cms/issues/9

--

Added:
 - Tests, travis integration, test namespaces and autoloading
 - Added APIs to better facilitate mocking (such as `file_exists`, `file_get_contents`, `copy`, etc)
 - Support for recipe files to end in `.tmpl` so that they don't get picked up by IDEs as first class classes