### PR TITLE
DEP Use double pipe for requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
         "lint-clean": "phpcbf src/"
     },
     "require": {
-        "composer-plugin-api": "^1.1|^2"
+        "composer-plugin-api": "^1.1 || ^2"
     },
     "require-dev": {
-        "composer/composer": "^1.2|2"
+        "composer/composer": "^1.2 || 2"
     },
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
Release as 1.5.0 once merged

Should use double pipe according to https://getcomposer.org/doc/articles/versions.md#version-range