### PR TITLE
Remove unnecessary methods from trait, adds Composer 2.3 compatibility

### DIFF
--- a/src/RecipeCommandBehaviour.php
+++ b/src/RecipeCommandBehaviour.php
@@ -15,31 +15,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 trait RecipeCommandBehaviour
 {
     /**
-     * Gets the application instance for this command.
-     *
-     * @return Application An Application instance
-     */
-    public abstract function getApplication();
-
-    /**
-     * @param  bool              $required
-     * @param  bool|null         $disablePlugins
-     * @throws \RuntimeException
-     * @return Composer
-     */
-    public abstract function getComposer($required = true, $disablePlugins = null);
-
-    /**
-     * Removes the cached composer instance
-     */
-    public abstract function resetComposer();
-
-    /**
-     * @return IOInterface
-     */
-    abstract public function getIO();
-
-    /**
      * @param OutputInterface $output
      * @param string $recipe
      * @param string $constraint


### PR DESCRIPTION
I believe this should fix things reported in https://github.com/silverstripe/recipe-plugin/issues/18