### PR TITLE
only write composer.json if there are changes

### DIFF
--- a/src/RecipeInstaller.php
+++ b/src/RecipeInstaller.php
@@ -16,6 +16,10 @@ use RegexIterator;
 
 class RecipeInstaller extends LibraryInstaller
 {
+    /**
+     * @var bool
+     */
+    private $hasWrittenFiles = false;
 
     public function __construct(IOInterface $io, Composer $composer)
     {
@@ -67,13 +71,15 @@ class RecipeInstaller extends LibraryInstaller
         }
 
         // If any files are written, modify composer.json with newly installed files
-        if ($installedFiles) {
+        if ($this->hasWrittenFiles) {
             sort($installedFiles);
             if (!isset($composerData['extra'])) {
                 $composerData['extra'] = [];
             }
             $composerData['extra'][$registrationKey] = $installedFiles;
             $composerFile->write($composerData);
+            // Reset the variable so that we can try this trick again later
+            $this->hasWrittenFiles = false;
         }
     }
 
@@ -115,6 +121,7 @@ class RecipeInstaller extends LibraryInstaller
             $this->io->write("  - Copying <info>$relativePath</info>");
             $this->filesystem->ensureDirectoryExists(dirname($destination ?? ''));
             copy($sourcePath ?? '', $destination ?? '');
+            $this->hasWrittenFiles = true;
         }
         return $relativePath;
     }


### PR DESCRIPTION
Caught this on a deployment to one of our platforms, even though no changes were made, the file was still read into memory and rewritten. Unfortunately, that triggered this issue: https://github.com/composer/composer/issues/9515 with an empty `"scripts": {}` key being rewritten to `"scripts": []`

This doesn't totally fix it but it does prevent a few unnecessary writes and saves the day in that one use-case