### PR TITLE
FIX Always put public resources in a public/ dir

### DIFF
--- a/src/RecipeInstaller.php
+++ b/src/RecipeInstaller.php
@@ -189,8 +189,7 @@ class RecipeInstaller extends LibraryInstaller
         $projectPath = dirname(realpath(Factory::getComposerFile() ?? '') ?? '');
 
         // Find public path
-        $candidatePublicPath = $projectPath . DIRECTORY_SEPARATOR . RecipePlugin::PUBLIC_PATH;
-        $publicPath = is_dir($candidatePublicPath ?? '') ? $candidatePublicPath : $projectPath;
+        $publicPath = $projectPath . DIRECTORY_SEPARATOR . RecipePlugin::PUBLIC_PATH;
 
         // Copy project files to root
         $name = $package->getName();


### PR DESCRIPTION
The `public/` directory is mandatory in CMS 5 (some of the functionality had already been explicitly deprecated in CMS 4 and so it has been removed in CMS 5) - but if the `public/` dir didn't exist yet, this plugin was still putting files from `extra.public-files` in composer.json of recipes into the project root.
This has been causing our behat tests to fail in CI for most modules.

## Note
Any deprecations required in CMS 4 or updates to documentation will be done separately - the primary purpose of this PR is to get builds passing again.

## Related RFC
https://github.com/silverstripe/silverstripe-framework/issues/8168

## Parent Issue
- https://github.com/silverstripeltd/product-issues/issues/642