### PR TITLE
API Update return type to match Symfony 7

### DIFF
--- a/src/RequireRecipeCommand.php
+++ b/src/RequireRecipeCommand.php
@@ -51,7 +51,7 @@ HELP
         );
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $recipe = $input->getArgument('recipe');
         $constraint = $input->getArgument('version');

--- a/src/UpdateRecipeCommand.php
+++ b/src/UpdateRecipeCommand.php
@@ -35,7 +35,7 @@ HELP
         );
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $recipe = $input->getArgument('recipe');
         $constraint = $input->getArgument('version');


### PR DESCRIPTION
We have determined that this exception to our definition of [public API](https://docs.silverstripe.org/en/project_governance/public_api/) is acceptable, as the likelihood of someone overriding methods in this repository is very low, and this change will allow for a greater range of installations for longer.

I'm not sure we have a good way to test this... @madmatt and @nlighteneddesign can one or both of you please confirm if this PR resolves the problem for this plugin?

Also @nlighteneddesign thank you for bringing this up in the first place, and for the original PRs. I've marked you as a co-author on this PR rather than opening the original one because I needed to change the commit message and it will be easier to get this across the line this way if any additional changes are required.

## Issues
- https://github.com/silverstripe/.github/issues/325